### PR TITLE
Initial asynchronous update is breaking widgets

### DIFF
--- a/src/main/java/uk/ac/cam/cl/data/DataManager.java
+++ b/src/main/java/uk/ac/cam/cl/data/DataManager.java
@@ -67,6 +67,9 @@ public class DataManager {
             latitude = 52.2053;
         }
 
+        // initial update must be synchronous so that when widgets load they have data they can use
+        update();
+
         daemon = new Thread(() -> {
             while (true) {
                 update();

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,3 @@
+.top-bar {
+    -fx-background-color: #ffffff;
+}


### PR DESCRIPTION
Performing the initial asynchronous commit is causing graph widgets to break.
This is because when the widgets are loaded they are calling `DataManager.getInstance().addListener()` which is in turn calling the plotting function for the widget.
If the initial update is asynchronous, then it is not guaranteed that the data is in the form which the plotting function expects it to be in and so the plot will fail because it receives a list of length zero rather than of length 7.
I know this may not be an ideal solution as it will increase the load time for the application but I feel as though it is a pragmatic one for the moment.